### PR TITLE
Use updated version of xmpp library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple client for the NWWS-2 OI ([NOAA Weather Wire Service](http://www.nws.noaa.gov/nwws/) version 2 Open Interface) written in PHP. The NOAA Weather Wire Service is a satellite data collection and dissemination system operated by the [National Weather Service](http://weather.gov), which was established in October 2000. Its purpose is to provide state and federal government, commercial users, media and private citizens with timely delivery of meteorological, hydrological, climatological and geophysical information. 
 
-This client uses Fabian Grutschus' popular [XMPP PHP library](https://github.com/fabiang/xmpp).
+This client uses an updated fork by zorn-v of Fabian Grutschus' popular [XMPP PHP library](https://github.com/zorn-v/xmpp).
 
 ## How do I run it?
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
         "require": {
                 "php": ">=7.0",
 		"ext-pcntl" : "*",
-        	"fabiang/xmpp": "^0.6.1"
+        	"zorn-v/xmpp": "^0.8.1"
         }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,79 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "af66c7922e345de05e3ecdc0103e121d",
-    "content-hash": "911690271f2602ebc0caf1493ddb7ee8",
+    "content-hash": "8d58c942c52a1799c66b396018f56e42",
     "packages": [
         {
-            "name": "fabiang/xmpp",
-            "version": "0.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fabiang/xmpp.git",
-                "reference": "47fdbe4a60ef0e726c4aaf39d6eb57afd42915c8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fabiang/xmpp/zipball/47fdbe4a60ef0e726c4aaf39d6eb57afd42915c8",
-                "reference": "47fdbe4a60ef0e726c4aaf39d6eb57afd42915c8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "psr/log": "~1.0"
-            },
-            "require-dev": {
-                "behat/behat": "~2.5",
-                "monolog/monolog": "~1.11",
-                "phpunit/phpunit": "~4.3",
-                "satooshi/php-coveralls": "~0.6"
-            },
-            "suggest": {
-                "psr/log-implementation": "Allows more advanced logging of the xmpp connection"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Fabiang\\Xmpp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Fabian Grutschus",
-                    "email": "f.grutschus@lubyte.de",
-                    "homepage": "http://www.lubyte.de/",
-                    "role": "developer"
-                }
-            ],
-            "description": "Library for XMPP protocol (Jabber) connections",
-            "homepage": "https://github.com/fabiang/xmpp",
-            "keywords": [
-                "jabber",
-                "xmpp"
-            ],
-            "time": "2014-11-20 08:59:24"
-        },
-        {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +51,72 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2018-11-20T15:27:04+00:00"
+        },
+        {
+            "name": "zorn-v/xmpp",
+            "version": "0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zorn-v/xmpp.git",
+                "reference": "163f7a2b1b54927dd3ed7c60702b26e73178f2d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zorn-v/xmpp/zipball/163f7a2b1b54927dd3ed7c60702b26e73178f2d9",
+                "reference": "163f7a2b1b54927dd3ed7c60702b26e73178f2d9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "behat/behat": "^2.5.5",
+                "monolog/monolog": "^1.22",
+                "phpunit/phpunit": "^5.7.20",
+                "satooshi/php-coveralls": "^1.0",
+                "symfony/console": "^2.8",
+                "symfony/dependency-injection": "^2.8",
+                "symfony/finder": "^2.8"
+            },
+            "suggest": {
+                "psr/log-implementation": "Allows more advanced logging of the xmpp connection"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fabiang\\Xmpp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabian Grutschus",
+                    "email": "f.grutschus@lubyte.de",
+                    "homepage": "http://www.lubyte.de/",
+                    "role": "developer"
+                },
+                {
+                    "name": "zorn-v",
+                    "role": "developer"
+                }
+            ],
+            "description": "Library for XMPP protocol (Jabber) connections",
+            "homepage": "https://github.com/zorn-v/xmpp",
+            "keywords": [
+                "jabber",
+                "xmpp"
+            ],
+            "time": "2018-04-26T06:48:43+00:00"
         }
     ],
     "packages-dev": [],

--- a/nwws2.php
+++ b/nwws2.php
@@ -58,7 +58,7 @@ while(TRUE) {
 
 	// join nwws channel
 	$channel = new Presence;
-	$channel->setTo('nwws@conference.' . $CONF['server'] . '/' . $CONF['resource'])->setNickName($CONF['username']);
+	$channel->setTo('nwws@conference.' . $CONF['server'] . '/' . $CONF['resource']);
 	$client->send($channel);
 
 	// start receiving products

--- a/nwws2.php
+++ b/nwws2.php
@@ -36,10 +36,10 @@ $CONF = json_decode(file_get_contents($argv[1]), TRUE);
 // start connect loop
 while(TRUE) {
 
-	printToLog("Connecting to " . $CONF['server']);
+	printToLog("Connecting to " . $CONF['server'] . " port " . $CONF['port']);
 
 	// connect to NWWS-OI server
-	$options = new Options('tcp://' . $CONF['server'] . ':5222');
+	$options = new Options('tcp://' . $CONF['server'] . ':' . $CONF['port']);
 	$options->setUsername($CONF['username'])->setPassword($CONF['password']);
 	$client = new Client($options);
 	try {


### PR DESCRIPTION
I've seen somewhat better performance out of this updated fork of the XMPP library when interfacing with the NWWS-OI server. I have a few more changes in the works to more gracefully handle server-initiated disconnects, which I get a lot of and I don't know if it's normal.