### PR TITLE
Graceful reconnect when server closes the connection

### DIFF
--- a/nwws2.php
+++ b/nwws2.php
@@ -65,6 +65,14 @@ while(TRUE) {
 	$xmlData = '';
 	$scanFlag = 0;
 	while(TRUE) {
+		
+		// check to make sure the socket is still open before doing anything else.
+		// The NWWS-OI server likes to kill connections from time to time.
+		if (!is_resource($client->getConnection()->getSocket()->getResource())) {
+			printToLog("Socket is invalid, server probably disconnected us");
+			continue 2;
+		}
+		
 		try {
 			$input = $client->getConnection()->receive();
 		} catch (Fabiang\Xmpp\Exception $e) {


### PR DESCRIPTION
Check to make sure socket is still open before attempting to read from it. This prevents the client from dumping fread() errors until the timeout is reached and the client reconnects.

Upon reconnection, the server will back up a few seconds and re-transmit some products so nothing should be missed.

I believe this also is a quick and dirty fix for #2 submitted by @theonemcdonald.